### PR TITLE
使用response body后重置stream读写指针位置

### DIFF
--- a/src/Http.php
+++ b/src/Http.php
@@ -218,9 +218,11 @@ class Http
             'Status' => $response->getStatusCode(),
             'Reason' => $response->getReasonPhrase(),
             'Headers' => $response->getHeaders(),
-            'Body' => strval($body = $response->getBody()) && $body->rewind(),
+            'Body' => strval($response->getBody()),
         ]);
 
+        $response->getBody()->rewind();
+        
         return $response;
     }
 

--- a/src/Http.php
+++ b/src/Http.php
@@ -218,7 +218,7 @@ class Http
             'Status' => $response->getStatusCode(),
             'Reason' => $response->getReasonPhrase(),
             'Headers' => $response->getHeaders(),
-            'Body' => strval($response->getBody()),
+            'Body' => strval($body = $response->getBody()) && $body->rewind(),
         ]);
 
         return $response;


### PR DESCRIPTION
在这里使用`strval($response->getBody())`获取响应`body`时，其实会隐性的将`body stream`读写指针移动到`stream`的末尾，这使在后文用`$response->getBody()->getContents()`会获取不到内容。使用`$body->rewind()`重置指针能修复这个问题。