### PR TITLE
Update composer.json

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -10,7 +10,7 @@
     "require": {
         "php": "^7.0",
         "pimple/pimple": "^3.0",
-        "doctrine/cache": "^1.6",
+        "doctrine/cache": ">=1.6",
         "symfony/http-foundation": "^3.3|^4.0",
         "guzzlehttp/guzzle": "^6.2",
         "monolog/monolog": "^1.22"


### PR DESCRIPTION
修改cache依赖版本号，否则无法正常拉取

  Problem 1
    - Installation request for hanson/foundation-sdk 3.0 -> satisfiable by hanson/foundation-sdk[3.0.0].
    - Conclusion: remove doctrine/cache v1.4.4
    - Conclusion: don't install doctrine/cache v1.4.4
    - hanson/foundation-sdk 3.0.0 requires doctrine/cache ^1.6 -> satisfiable by doctrine/cache[v1.6.0, v1.6.1, v1.6.2, v1.7.0, v1.7.1, v1.8.0].
    - Can only install one of: doctrine/cache[v1.6.0, v1.4.4].
    - Can only install one of: doctrine/cache[v1.6.1, v1.4.4].
    - Can only install one of: doctrine/cache[v1.6.2, v1.4.4].
    - Can only install one of: doctrine/cache[v1.7.0, v1.4.4].
    - Can only install one of: doctrine/cache[v1.7.1, v1.4.4].
    - Can only install one of: doctrine/cache[v1.8.0, v1.4.4].
    - Installation request for doctrine/cache (locked at v1.4.4) -> satisfiable by doctrine/cache[v1.4.4].