### PR TITLE
当使用该composer给client赋值了一个错误的类库时，应该给错误提示

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,6 +1,7 @@
 composer.phar
 /vendor/
 /.idea/
+composer.lock
 
 # Commit your application's lock file http://getcomposer.org/doc/01-basic-usage.md#composer-lock-the-lock-file
 # You may choose to ignore a library lock file http://getcomposer.org/doc/02-libraries.md#lock-file

--- a/src/Http.php
+++ b/src/Http.php
@@ -3,6 +3,7 @@
 namespace Hanson\Foundation;
 
 use GuzzleHttp\Client as HttpClient;
+use GuzzleHttp\ClientInterface;
 use GuzzleHttp\HandlerStack;
 use Hanson\Foundation\Exception\HttpException;
 use Psr\Http\Message\ResponseInterface;
@@ -147,11 +148,8 @@ class Http
      * @author tu6ge
      * @date 2019/8/15 下午11:00
      */
-    public function setClient(HttpClient $client)
+    public function setClient(ClientInterface $client)
     {
-        if (!($this->client instanceof HttpClient)) {
-            throw new HttpException('http client is illegal');
-        }
         $this->client = $client;
 
         return $this;

--- a/src/Http.php
+++ b/src/Http.php
@@ -141,13 +141,17 @@ class Http
 
     /**
      * Set GuzzleHttp\Client.
-     *
-     * @param \GuzzleHttp\Client $client
-     *
-     * @return Http
+     * @param HttpClient $client
+     * @return $this
+     * @throws HttpException
+     * @author tu6ge
+     * @date 2019/8/15 下午11:00
      */
     public function setClient(HttpClient $client)
     {
+        if (!($this->client instanceof HttpClient)) {
+            throw new HttpException('http client is illegal');
+        }
         $this->client = $client;
 
         return $this;
@@ -160,7 +164,7 @@ class Http
      */
     public function getClient()
     {
-        if (!($this->client instanceof HttpClient)) {
+        if (empty($this->client)) {
             $this->client = new HttpClient();
         }
 


### PR DESCRIPTION
当使用该composer给client赋值了一个错误的类库时，应该给错误提示，而不应该自动给他赋值guzzle,这样可以更容易发现问题，而不会导致debug的时候找不到头绪